### PR TITLE
CSS color name support

### DIFF
--- a/lib/ChronosMdParser.ts
+++ b/lib/ChronosMdParser.ts
@@ -373,13 +373,17 @@ export class ChronosMdParser {
     };
 
     if (!colorMap[color]) {
-      console.warn(`Color "${color}" not recognized.`);
-      return undefined;
+      // Support native CSS colors by using the specified string directly.
+      // Preserve previous behavior for Obsidian named colors (in case a user relied on a theme overwriting the basic color values)
+      // This will result in unexpected behavior if the value is not a valid CSS color value (i.e. name, rgb, etc.).
+      return opacity === "solid"
+        ? `${color.replace(';','_')}` // sanitize input to reduce the chance of some sort of display exploit
+        : `${color}; opacity(var(--chronos-opacity))`;
+    } else {
+      return opacity === "solid"
+        ? `var(--color-${colorMap[color]})`
+        : `rgba(var(--color-${colorMap[color]}-rgb), var(--chronos-opacity))`;
     }
-
-    return opacity === "solid"
-      ? `var(--color-${colorMap[color]})`
-      : `rgba(var(--color-${colorMap[color]}-rgb), var(--chronos-opacity))`;
   }
 
   private _ensureChronologicalDates(


### PR DESCRIPTION
This implements CSS color name support but should preserve the current behavior with existing Obsidian colors (just in case a user has a theme that rewrites them).  It should support all CSS color names, and it should also sanitize input just in case there is some way it could hijack styles for other elements (I don't think there is, but it replaces semicolon ; with underscore _).

I got my toolchain worked out and was able to test this.  It works as far as I can tell.  RGB color codes prefixed by # will not work because of the way the plugin uses prefixes for tokens (in fact that will break the title of the timeline entity).  It looks like CSS functions won't work either but I have to spend more time to figure out why.

Again, I am new at Obsidian and TS, so I might have missed something and I definitely understand if you need to deny the request.